### PR TITLE
[codex] Add loaf scoring feature

### DIFF
--- a/app.py
+++ b/app.py
@@ -280,16 +280,150 @@ def show_palette_swatches(results):
             )
 
 
+def apply_pastel_theme():
+    st.markdown(
+        """
+        <style>
+        :root {
+            --cat-ink: #3f3442;
+            --cat-muted: #6d6470;
+            --cat-cream: #fff9f2;
+            --cat-blush: #ffe8ec;
+            --cat-mint: #dff5e8;
+            --cat-lavender: #eee7ff;
+            --cat-blue: #dff0ff;
+            --cat-peach: #ffe4cf;
+            --cat-border: #eadde6;
+            --cat-accent: #cf7892;
+        }
+
+        .stApp {
+            color: var(--cat-ink);
+            background:
+                linear-gradient(135deg, #fff7ed 0%, #fff0f6 42%, #eef8f2 100%);
+        }
+
+        [data-testid="stSidebar"] {
+            background: linear-gradient(180deg, #fff4df 0%, #f1ecff 100%);
+            border-right: 1px solid var(--cat-border);
+        }
+
+        [data-testid="stAppViewContainer"] .main .block-container {
+            padding-top: 2.4rem;
+            max-width: 1180px;
+        }
+
+        h1, h2, h3 {
+            color: var(--cat-ink);
+            letter-spacing: 0;
+        }
+
+        h1 {
+            color: #5b4050;
+            font-weight: 760;
+        }
+
+        p, li, label, div {
+            letter-spacing: 0;
+        }
+
+        [data-testid="stMarkdownContainer"] p {
+            color: var(--cat-muted);
+        }
+
+        .cat-feature-note {
+            background: linear-gradient(135deg, var(--cat-cream), var(--cat-lavender));
+            border: 1px solid var(--cat-border);
+            border-left: 6px solid var(--cat-accent);
+            border-radius: 8px;
+            padding: 1rem 1.1rem;
+            margin: 0.45rem 0 1.2rem;
+            box-shadow: 0 10px 28px rgba(97, 67, 86, 0.08);
+        }
+
+        .cat-feature-note p {
+            margin: 0.35rem 0;
+            color: var(--cat-ink);
+            line-height: 1.48;
+        }
+
+        .cat-feature-note strong {
+            color: #7d4a5e;
+        }
+
+        [data-testid="stTabs"] button {
+            background: #fffaf4;
+            border: 1px solid var(--cat-border);
+            border-radius: 8px 8px 0 0;
+            color: #6b5a66;
+            font-weight: 650;
+            margin-right: 0.25rem;
+        }
+
+        [data-testid="stTabs"] button[aria-selected="true"] {
+            background: var(--cat-mint);
+            color: #365846;
+            border-bottom-color: var(--cat-mint);
+        }
+
+        [data-testid="stFileUploaderDropzone"] {
+            background: rgba(255, 255, 255, 0.74);
+            border: 1px dashed #d7b8ca;
+            border-radius: 8px;
+        }
+
+        [data-testid="stFileUploaderDropzone"] button,
+        .stButton button {
+            background: var(--cat-peach);
+            border: 1px solid #efc3aa;
+            border-radius: 8px;
+            color: #5a3f36;
+            font-weight: 650;
+        }
+
+        [data-testid="stAlert"] {
+            background: rgba(223, 245, 232, 0.78);
+            border: 1px solid #badfcc;
+            border-radius: 8px;
+            color: #355444;
+        }
+
+        [data-testid="stMetric"] {
+            background: #fffaf4;
+            border: 1px solid var(--cat-border);
+            border-radius: 8px;
+            padding: 0.85rem 1rem;
+        }
+
+        [data-testid="stTable"] {
+            border: 1px solid var(--cat-border);
+            border-radius: 8px;
+            overflow: hidden;
+        }
+
+        div[data-baseweb="select"] > div,
+        div[data-baseweb="slider"] {
+            color: var(--cat-ink);
+        }
+        </style>
+        """,
+        unsafe_allow_html=True,
+    )
+
+
 def feature_note(description, calculation, instructions, interpretation=None):
     lines = [
-        f"**What it does:** {description}",
-        f"**Calculation:** {calculation}",
-        f"**How to use it:** {instructions}",
+        f"<p><strong>What it does:</strong> {description}</p>",
+        f"<p><strong>How it works:</strong> {calculation}</p>",
+        f"<p><strong>How to use it:</strong> {instructions}</p>",
     ]
     if interpretation:
-        lines.append(f"**How to read it:** {interpretation}")
+        lines.append(f"<p><strong>How to read it:</strong> {interpretation}</p>")
 
-    st.info("\n\n".join(lines))
+    st.markdown(
+        f"<div class=\"cat-feature-note\">{''.join(lines)}</div>",
+        unsafe_allow_html=True,
+    )
 
 
 def render_single_analysis(num_colors, method):
@@ -499,6 +633,7 @@ def render_loaf_scorer():
 
 def main():
     st.set_page_config(page_title="Cat Color Quantifier", page_icon="cat", layout="wide")
+    apply_pastel_theme()
     st.title("Cat Color Quantifier")
     st.write(
         "Analyze cat colors, compare palettes, match fur against fabric, and score loafiness."

--- a/app.py
+++ b/app.py
@@ -294,16 +294,19 @@ def feature_note(description, calculation, instructions, interpretation=None):
 
 def render_single_analysis(num_colors, method):
     feature_note(
-        "Finds the main fur colors in one uploaded cat image.",
+        "Finds the main colors in your cat's fur.",
         (
-            f"The app keeps foreground pixels, samples up to {MAX_CLUSTER_PIXELS:,} of "
-            "them for speed, clusters RGB values with the selected method, then reports "
-            "each cluster as a percentage of sampled foreground color."
+            "It looks at the visible cat pixels and groups similar colors together. "
+            "For speed, it uses a sample of the image rather than every single pixel."
         ),
-        "Upload a cat image, ideally with a transparent or simple background.",
         (
-            "Larger percentages are more dominant colors. The RGB plot shows a sampled "
-            "view of how separated or blended the color clusters are."
+            "Upload a cat image that has already been cropped or segmented so the "
+            "background is transparent. A clean white background can also work, but "
+            "busy backgrounds will confuse the results."
+        ),
+        (
+            "Bigger percentages mean that color appears more often in the cat's fur. "
+            "The color chart is a quick summary of the fur palette."
         ),
     )
 
@@ -344,16 +347,18 @@ def render_single_analysis(num_colors, method):
 
 def render_cat_comparison(num_colors, method):
     feature_note(
-        "Compares the dominant-color palette of one reference cat against other cats.",
+        "Compares one cat's fur palette with other cats.",
         (
-            "For each reference color, the app finds the nearest comparison color in RGB "
-            "space, weights that distance by the reference color percentage, and averages "
-            "the result in both directions."
+            "It compares the main fur colors from each image and checks how close those "
+            "palettes are to one another."
         ),
-        "Upload one reference cat, then upload one or more cats to compare against it.",
         (
-            "Lower color distance means the palettes are closer. Higher similarity means "
-            "the comparison cat is more color-similar to the reference cat."
+            "Upload one reference cat, then upload one or more cats to compare. Use "
+            "segmented or transparent-background cat images for the fairest comparison."
+        ),
+        (
+            "Higher similarity means the cats have more similar fur colors. Lower color "
+            "distance means the palettes are closer."
         ),
     )
 
@@ -396,16 +401,18 @@ def render_cat_comparison(num_colors, method):
 
 def render_jacket_matcher(num_colors, method):
     feature_note(
-        "Estimates how visible cat fur may be on a jacket.",
+        "Estimates how much your cat's fur might show up on a jacket.",
         (
-            "The app compares the cat palette and jacket palette using the same weighted "
-            "RGB distance as cat comparison, then scales that mismatch to a 0-100 risk "
-            "score."
+            "It compares the cat's fur colors with the jacket colors. Bigger color "
+            "differences mean shed fur is more likely to stand out."
         ),
-        "Upload a cat photo and a jacket photo.",
         (
-            "Higher risk means stronger color contrast, so shed fur is more likely to "
-            "stand out. Lower risk means the jacket color is closer to the cat palette."
+            "Upload a segmented cat image and a jacket photo. For the jacket, try to use "
+            "a photo where the jacket fills most of the image."
+        ),
+        (
+            "A higher risk score means fur will probably be more noticeable. A lower "
+            "score means the jacket is closer to your cat's fur colors."
         ),
     )
 
@@ -447,16 +454,19 @@ def render_jacket_matcher(num_colors, method):
 
 def render_loaf_scorer():
     feature_note(
-        "Scores how loaf-like the visible cat shape is.",
+        "Scores how loaf-like your cat's shape is.",
         (
-            "The app builds a foreground mask, crops it to the cat shape, estimates edges "
-            "for perimeter, then combines circularity, width-to-height aspect ratio, and "
-            "mask coverage into a 0-10 score."
+            "It looks at the cat's outline and rewards a compact, rounded, filled-in "
+            "shape. A classic loaf should look wide, smooth, and tucked-in."
         ),
-        "Upload a loafing cat image with a transparent, white, or otherwise clean background.",
         (
-            "A higher score means the silhouette is compact, oval, and filled-in. Busy "
-            "backgrounds or visible paws/tails can lower the score."
+            "Upload a loafing cat image that has been cropped or segmented with a "
+            "transparent background. A clean white background can work, but cluttered "
+            "backgrounds will make the score less reliable."
+        ),
+        (
+            "A higher score means a stronger loaf. Visible paws, tails, stretched poses, "
+            "or background clutter can lower the score."
         ),
     )
 

--- a/app.py
+++ b/app.py
@@ -280,7 +280,33 @@ def show_palette_swatches(results):
             )
 
 
+def feature_note(description, calculation, instructions, interpretation=None):
+    lines = [
+        f"**What it does:** {description}",
+        f"**Calculation:** {calculation}",
+        f"**How to use it:** {instructions}",
+    ]
+    if interpretation:
+        lines.append(f"**How to read it:** {interpretation}")
+
+    st.info("\n\n".join(lines))
+
+
 def render_single_analysis(num_colors, method):
+    feature_note(
+        "Finds the main fur colors in one uploaded cat image.",
+        (
+            f"The app keeps foreground pixels, samples up to {MAX_CLUSTER_PIXELS:,} of "
+            "them for speed, clusters RGB values with the selected method, then reports "
+            "each cluster as a percentage of sampled foreground color."
+        ),
+        "Upload a cat image, ideally with a transparent or simple background.",
+        (
+            "Larger percentages are more dominant colors. The RGB plot shows a sampled "
+            "view of how separated or blended the color clusters are."
+        ),
+    )
+
     uploaded = st.file_uploader("Upload a cat image", type=["png", "jpg", "jpeg", "webp"])
     if uploaded is None:
         st.info("Upload an image to get started.")
@@ -317,6 +343,20 @@ def render_single_analysis(num_colors, method):
 
 
 def render_cat_comparison(num_colors, method):
+    feature_note(
+        "Compares the dominant-color palette of one reference cat against other cats.",
+        (
+            "For each reference color, the app finds the nearest comparison color in RGB "
+            "space, weights that distance by the reference color percentage, and averages "
+            "the result in both directions."
+        ),
+        "Upload one reference cat, then upload one or more cats to compare against it.",
+        (
+            "Lower color distance means the palettes are closer. Higher similarity means "
+            "the comparison cat is more color-similar to the reference cat."
+        ),
+    )
+
     reference = st.file_uploader(
         "Reference cat", type=["png", "jpg", "jpeg", "webp"], key="reference-cat"
     )
@@ -355,6 +395,20 @@ def render_cat_comparison(num_colors, method):
 
 
 def render_jacket_matcher(num_colors, method):
+    feature_note(
+        "Estimates how visible cat fur may be on a jacket.",
+        (
+            "The app compares the cat palette and jacket palette using the same weighted "
+            "RGB distance as cat comparison, then scales that mismatch to a 0-100 risk "
+            "score."
+        ),
+        "Upload a cat photo and a jacket photo.",
+        (
+            "Higher risk means stronger color contrast, so shed fur is more likely to "
+            "stand out. Lower risk means the jacket color is closer to the cat palette."
+        ),
+    )
+
     cat = st.file_uploader("Cat photo", type=["png", "jpg", "jpeg", "webp"], key="jacket-cat")
     jacket = st.file_uploader(
         "Jacket photo", type=["png", "jpg", "jpeg", "webp"], key="jacket-photo"
@@ -392,6 +446,20 @@ def render_jacket_matcher(num_colors, method):
 
 
 def render_loaf_scorer():
+    feature_note(
+        "Scores how loaf-like the visible cat shape is.",
+        (
+            "The app builds a foreground mask, crops it to the cat shape, estimates edges "
+            "for perimeter, then combines circularity, width-to-height aspect ratio, and "
+            "mask coverage into a 0-10 score."
+        ),
+        "Upload a loafing cat image with a transparent, white, or otherwise clean background.",
+        (
+            "A higher score means the silhouette is compact, oval, and filled-in. Busy "
+            "backgrounds or visible paws/tails can lower the score."
+        ),
+    )
+
     uploaded = st.file_uploader(
         "Upload a loafing cat image", type=["png", "jpg", "jpeg", "webp"], key="loaf-cat"
     )

--- a/app.py
+++ b/app.py
@@ -4,7 +4,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import streamlit as st
 from matplotlib.colors import ListedColormap
-from PIL import Image
+from PIL import Image, ImageFilter
 from sklearn.cluster import MiniBatchKMeans
 from sklearn.mixture import GaussianMixture
 
@@ -165,6 +165,35 @@ def color_mismatch_score(cat_results, jacket_results):
         return None
 
     return min(100, distance / 441.67 * 100)
+
+
+def loaf_score(mask):
+    if not mask.any():
+        return {"score": 0.0, "circularity": 0.0, "aspect": 0.0, "coverage": 0.0}
+
+    rows, cols = np.where(mask)
+    height = rows.max() - rows.min() + 1
+    width = cols.max() - cols.min() + 1
+    crop = mask[rows.min() : rows.max() + 1, cols.min() : cols.max() + 1]
+    area = int(crop.sum())
+
+    mask_img = Image.fromarray((crop * 255).astype(np.uint8), mode="L")
+    edges = np.asarray(mask_img.filter(ImageFilter.FIND_EDGES)) > 0
+    perimeter = max(1, int(edges.sum()))
+
+    circularity = min(1.0, (4 * np.pi * area) / (perimeter * perimeter))
+    aspect_ratio = width / max(1, height)
+    aspect_score = max(0.0, 1.0 - abs(aspect_ratio - 1.55) / 1.55)
+    coverage = area / max(1, width * height)
+    coverage_score = min(1.0, coverage / 0.75)
+
+    score = 10 * (0.45 * circularity + 0.35 * aspect_score + 0.20 * coverage_score)
+    return {
+        "score": round(float(score), 1),
+        "circularity": round(float(circularity), 3),
+        "aspect": round(float(aspect_ratio), 2),
+        "coverage": round(float(coverage), 3),
+    }
 
 
 def donut_figure(results, title="Pixel Color Clusters"):
@@ -362,11 +391,39 @@ def render_jacket_matcher(num_colors, method):
         st.success("Low contrast: fur should be less obvious on this jacket.")
 
 
+def render_loaf_scorer():
+    uploaded = st.file_uploader(
+        "Upload a loafing cat image", type=["png", "jpg", "jpeg", "webp"], key="loaf-cat"
+    )
+    if uploaded is None:
+        st.info("Upload a cat image with a clean or transparent background.")
+        return
+
+    img = uploaded_image(uploaded)
+    _, mask = foreground_pixels(img)
+    metrics = loaf_score(mask)
+
+    col1, col2 = st.columns(2)
+    with col1:
+        st.subheader("Input image")
+        st.image(img, use_container_width=True)
+    with col2:
+        st.subheader("Loaf score")
+        st.metric("Loafiness", f"{metrics['score']}/10")
+        st.table(
+            [
+                {"Metric": "Circularity", "Value": metrics["circularity"]},
+                {"Metric": "Aspect ratio", "Value": metrics["aspect"]},
+                {"Metric": "Mask coverage", "Value": metrics["coverage"]},
+            ]
+        )
+
+
 def main():
     st.set_page_config(page_title="Cat Color Quantifier", page_icon="cat", layout="wide")
     st.title("Cat Color Quantifier")
     st.write(
-        "Analyze cat colors, compare palettes, and match fur against fabric."
+        "Analyze cat colors, compare palettes, match fur against fabric, and score loafiness."
     )
 
     with st.sidebar:
@@ -379,8 +436,8 @@ def main():
             f"Color models use up to {MAX_CLUSTER_PIXELS:,} foreground pixels for speed."
         )
 
-    tab_analyze, tab_compare, tab_jacket = st.tabs(
-        ["Analyze", "Compare cats", "Jacket matcher"]
+    tab_analyze, tab_compare, tab_jacket, tab_loaf = st.tabs(
+        ["Analyze", "Compare cats", "Jacket matcher", "Loaf scorer"]
     )
 
     with tab_analyze:
@@ -391,6 +448,9 @@ def main():
 
     with tab_jacket:
         render_jacket_matcher(num_colors, method)
+
+    with tab_loaf:
+        render_loaf_scorer()
 
 
 if __name__ == "__main__":

--- a/app.py
+++ b/app.py
@@ -285,27 +285,27 @@ def apply_pastel_theme():
         """
         <style>
         :root {
-            --cat-ink: #3f3442;
-            --cat-muted: #6d6470;
-            --cat-cream: #fff9f2;
-            --cat-blush: #ffe8ec;
-            --cat-mint: #dff5e8;
-            --cat-lavender: #eee7ff;
-            --cat-blue: #dff0ff;
-            --cat-peach: #ffe4cf;
-            --cat-border: #eadde6;
-            --cat-accent: #cf7892;
+            --cat-ink: #171626;
+            --cat-muted: #3c3854;
+            --cat-cream: #fff4d6;
+            --cat-paper: #fffaf0;
+            --cat-gold: #ffd45a;
+            --cat-red: #f1433b;
+            --cat-red-deep: #c72935;
+            --cat-green: #198d69;
+            --cat-mint: #dfe8d6;
+            --cat-border: #171626;
         }
 
         .stApp {
             color: var(--cat-ink);
             background:
-                linear-gradient(135deg, #fff7ed 0%, #fff0f6 42%, #eef8f2 100%);
+                linear-gradient(115deg, #fff0bd 0%, #fff0d8 44%, #dfe8d6 100%);
         }
 
         [data-testid="stSidebar"] {
-            background: linear-gradient(180deg, #fff4df 0%, #f1ecff 100%);
-            border-right: 1px solid var(--cat-border);
+            background: linear-gradient(180deg, #ffe7a8 0%, #f7ead4 58%, #dfe8d6 100%);
+            border-right: 3px solid var(--cat-border);
         }
 
         [data-testid="stAppViewContainer"] .main .block-container {
@@ -319,8 +319,12 @@ def apply_pastel_theme():
         }
 
         h1 {
-            color: #5b4050;
-            font-weight: 760;
+            color: var(--cat-red);
+            font-size: 4.5rem;
+            font-weight: 850;
+            line-height: 0.95;
+            margin-bottom: 0.4rem;
+            text-shadow: 0.07em 0.07em 0 var(--cat-gold);
         }
 
         p, li, label, div {
@@ -332,13 +336,13 @@ def apply_pastel_theme():
         }
 
         .cat-feature-note {
-            background: linear-gradient(135deg, var(--cat-cream), var(--cat-lavender));
-            border: 1px solid var(--cat-border);
-            border-left: 6px solid var(--cat-accent);
+            background: var(--cat-paper);
+            border: 3px solid var(--cat-border);
+            border-left: 12px solid var(--cat-green);
             border-radius: 8px;
-            padding: 1rem 1.1rem;
-            margin: 0.45rem 0 1.2rem;
-            box-shadow: 0 10px 28px rgba(97, 67, 86, 0.08);
+            padding: 1rem 1.15rem;
+            margin: 1.35rem 0 1.35rem;
+            box-shadow: 7px 7px 0 rgba(23, 22, 38, 0.13);
         }
 
         .cat-feature-note p {
@@ -348,55 +352,92 @@ def apply_pastel_theme():
         }
 
         .cat-feature-note strong {
-            color: #7d4a5e;
+            color: var(--cat-red-deep);
+        }
+
+        [data-testid="stTabs"] div[data-baseweb="tab-list"] {
+            gap: 0.85rem;
+            border-bottom: 5px solid var(--cat-red);
+            padding: 0.25rem 0 1.2rem;
+            margin: 0.9rem 0 1.2rem;
+        }
+
+        [data-testid="stTabs"] div[data-baseweb="tab-list"] button {
+            flex: 0 0 auto;
+        }
+
+        [data-testid="stTabs"] div[data-baseweb="tab-highlight"],
+        [data-testid="stTabs"] div[data-baseweb="tab-border"] {
+            display: none;
         }
 
         [data-testid="stTabs"] button {
-            background: #fffaf4;
-            border: 1px solid var(--cat-border);
-            border-radius: 8px 8px 0 0;
-            color: #6b5a66;
-            font-weight: 650;
-            margin-right: 0.25rem;
+            background: var(--cat-paper);
+            border: 3px solid var(--cat-border);
+            border-radius: 8px;
+            box-shadow: 0 7px 0 var(--cat-ink);
+            color: var(--cat-ink);
+            font-weight: 800;
+            min-height: 46px;
+            padding: 0.55rem 1.15rem;
+            transition: transform 120ms ease, box-shadow 120ms ease, background 120ms ease;
+        }
+
+        [data-testid="stTabs"] button:hover {
+            background: #fff6d7;
+            transform: translateY(2px);
+            box-shadow: 0 5px 0 var(--cat-ink);
         }
 
         [data-testid="stTabs"] button[aria-selected="true"] {
-            background: var(--cat-mint);
-            color: #365846;
-            border-bottom-color: var(--cat-mint);
+            background: var(--cat-red);
+            color: #ffffff;
+            box-shadow: 0 7px 0 var(--cat-ink);
+        }
+
+        [data-testid="stTabs"] button p {
+            color: inherit;
+            font-size: 1rem;
+            font-weight: 800;
+            line-height: 1.1;
+            margin: 0;
+            padding: 0;
         }
 
         [data-testid="stFileUploaderDropzone"] {
-            background: rgba(255, 255, 255, 0.74);
-            border: 1px dashed #d7b8ca;
+            background: rgba(255, 250, 240, 0.86);
+            border: 3px dashed #d7a94b;
             border-radius: 8px;
         }
 
         [data-testid="stFileUploaderDropzone"] button,
         .stButton button {
-            background: var(--cat-peach);
-            border: 1px solid #efc3aa;
+            background: var(--cat-gold);
+            border: 3px solid var(--cat-border);
             border-radius: 8px;
-            color: #5a3f36;
-            font-weight: 650;
+            box-shadow: 0 5px 0 var(--cat-ink);
+            color: var(--cat-ink);
+            font-weight: 800;
         }
 
         [data-testid="stAlert"] {
-            background: rgba(223, 245, 232, 0.78);
-            border: 1px solid #badfcc;
+            background: rgba(255, 250, 240, 0.88);
+            border: 3px solid var(--cat-border);
+            border-left: 10px solid var(--cat-green);
             border-radius: 8px;
-            color: #355444;
+            color: var(--cat-ink);
         }
 
         [data-testid="stMetric"] {
-            background: #fffaf4;
-            border: 1px solid var(--cat-border);
+            background: var(--cat-paper);
+            border: 3px solid var(--cat-border);
             border-radius: 8px;
             padding: 0.85rem 1rem;
+            box-shadow: 6px 6px 0 rgba(23, 22, 38, 0.12);
         }
 
         [data-testid="stTable"] {
-            border: 1px solid var(--cat-border);
+            border: 3px solid var(--cat-border);
             border-radius: 8px;
             overflow: hidden;
         }

--- a/tests/test_app_helpers.py
+++ b/tests/test_app_helpers.py
@@ -4,6 +4,7 @@ from app import (
     cluster_pixels,
     color_mismatch_score,
     distance_to_similarity,
+    loaf_score,
     palette_distance,
     sample_indices,
 )
@@ -66,6 +67,17 @@ def test_palette_distance_is_symmetric():
     assert palette_distance(palette_a, palette_b) == palette_distance(
         palette_b, palette_a
     )
+
+
+def test_loaf_score_rewards_compact_oval_mask():
+    rows, cols = np.ogrid[:80, :120]
+    oval = ((rows - 40) / 25) ** 2 + ((cols - 60) / 42) ** 2 <= 1
+
+    metrics = loaf_score(oval)
+
+    assert 0 <= metrics["score"] <= 10
+    assert metrics["score"] > 5
+    assert metrics["aspect"] > 1
 
 
 def test_sample_indices_caps_rows_reproducibly():


### PR DESCRIPTION
## What changed
- Added a loaf scorer tab.
- Scores foreground masks using circularity, aspect ratio, edge-derived perimeter, and mask coverage.
- Added a focused test for a compact oval loaf-like mask.

## Why
This provides a simple automatic 0-10 loafiness score for cat images with clean or transparent backgrounds.

## Validation
- `C:\Users\Andrew\Anaconda3\python.exe -m pytest -q -p no:cacheprovider` in `C:\tmp\pixelcat-pr-issue4`

Closes #4
