### PR TITLE
Improve comparison and loaf accuracy

### DIFF
--- a/src/pixelcat/image_processing.py
+++ b/src/pixelcat/image_processing.py
@@ -1,3 +1,4 @@
+from collections import deque
 from io import BytesIO
 
 import numpy as np
@@ -14,13 +15,31 @@ def load_image_from_bytes(file_bytes) -> Image.Image:
 
     alpha = data[:, :, 3]
     if alpha.min() == 255:
-        white_bg = (
-            (data[:, :, 0] > 200)
-            & (data[:, :, 1] > 200)
-            & (data[:, :, 2] > 200)
-        )
+        # Estimate the studio background from border pixels and remove only the
+        # connected border region. This handles white/grey backdrops without
+        # deleting light fur or fabric inside the subject.
+        rgb = data[:, :, :3].astype(float)
+        border = np.concatenate((rgb[0], rgb[-1], rgb[:, 0], rgb[:, -1]))
+        background_color = np.median(border, axis=0)
+        color_distance = np.linalg.norm(rgb - background_color, axis=2)
+        candidate = color_distance < 32
+        background = np.zeros(candidate.shape, dtype=bool)
+        queue = deque()
+        edge = np.zeros(candidate.shape, dtype=bool)
+        edge[[0, -1], :] = True
+        edge[:, [0, -1]] = True
+        for row, col in np.argwhere(candidate & edge):
+            background[row, col] = True
+            queue.append((row, col))
+        while queue:
+            row, col = queue.popleft()
+            for rr, cc in ((row - 1, col), (row + 1, col), (row, col - 1), (row, col + 1)):
+                if (0 <= rr < candidate.shape[0] and 0 <= cc < candidate.shape[1]
+                        and candidate[rr, cc] and not background[rr, cc]):
+                    background[rr, cc] = True
+                    queue.append((rr, cc))
         data = data.copy()
-        data[white_bg, 3] = 0
+        data[background, 3] = 0
         img = Image.fromarray(data, "RGBA")
 
     return img

--- a/src/pixelcat/scores.py
+++ b/src/pixelcat/scores.py
@@ -1,5 +1,18 @@
 import numpy as np
-from PIL import Image, ImageFilter
+
+
+def rgb_to_lab(rgb):
+    """Convert sRGB values to CIE Lab (D65), where distance is perceptual."""
+    values = np.asarray(rgb, dtype=float) / 255.0
+    linear = np.where(values <= 0.04045, values / 12.92, ((values + 0.055) / 1.055) ** 2.4)
+    xyz = linear @ np.array(
+        [[0.4124564, 0.2126729, 0.0193339],
+         [0.3575761, 0.7151522, 0.1191920],
+         [0.1804375, 0.0721750, 0.9503041]]
+    )
+    scaled = xyz / np.array([0.95047, 1.0, 1.08883])
+    f = np.where(scaled > 0.008856, np.cbrt(scaled), 7.787 * scaled + 16 / 116)
+    return np.array([116 * f[1] - 16, 500 * (f[0] - f[1]), 200 * (f[1] - f[2])])
 
 
 def directed_palette_distance(results_a, results_b):
@@ -8,9 +21,9 @@ def directed_palette_distance(results_a, results_b):
 
     distance = 0.0
     for color_a in results_a:
-        rgb_a = np.array(color_a["rgb"], dtype=float)
+        lab_a = rgb_to_lab(color_a["rgb"])
         nearest = min(
-            np.linalg.norm(rgb_a - np.array(color_b["rgb"], dtype=float))
+            np.linalg.norm(lab_a - rgb_to_lab(color_b["rgb"]))
             for color_b in results_b
         )
         distance += nearest * (color_a["percent"] / 100)
@@ -31,20 +44,28 @@ def distance_to_similarity(distance):
     if distance is None:
         return None
 
-    return max(0.0, 100 - distance / 441.67 * 100)
+    return float(100 * np.exp(-((distance / 32) ** 1.35)))
 
 
 def color_mismatch_score(cat_results, jacket_results):
-    distance = palette_distance(cat_results, jacket_results)
+    # Visibility is directional: every cat-fur color needs a close fabric color;
+    # colors present only in the jacket should not make the fur look riskier.
+    distance = directed_palette_distance(cat_results, jacket_results)
     if distance is None:
         return None
 
-    return min(100, distance / 441.67 * 100)
+    return float(100 * (1 - np.exp(-((distance / 28) ** 1.35))))
 
 
 def loaf_score(mask):
     if not mask.any():
-        return {"score": 0.0, "circularity": 0.0, "aspect": 0.0, "coverage": 0.0}
+        return {
+            "score": 0.0,
+            "circularity": 0.0,
+            "aspect": 0.0,
+            "coverage": 0.0,
+            "compactness": 0.0,
+        }
 
     rows, cols = np.where(mask)
     height = rows.max() - rows.min() + 1
@@ -52,21 +73,40 @@ def loaf_score(mask):
     crop = mask[rows.min() : rows.max() + 1, cols.min() : cols.max() + 1]
     area = int(crop.sum())
 
-    mask_img = Image.fromarray((crop * 255).astype(np.uint8), mode="L")
-    edges = np.asarray(mask_img.filter(ImageFilter.FIND_EDGES)) > 0
-    perimeter = max(1, int(edges.sum()))
+    padded = np.pad(crop, 1, constant_values=False)
+    horizontal = np.count_nonzero(padded[:, 1:] != padded[:, :-1])
+    vertical = np.count_nonzero(padded[1:, :] != padded[:-1, :])
+    perimeter = max(1, horizontal + vertical)
 
     circularity = min(1.0, (4 * np.pi * area) / (perimeter * perimeter))
-    aspect_ratio = width / max(1, height)
-    aspect_score = max(0.0, 1.0 - abs(aspect_ratio - 1.55) / 1.55)
+    # PCA makes the aspect ratio independent of camera rotation.
+    points = np.column_stack((cols, rows)).astype(float)
+    eigenvalues = np.linalg.eigvalsh(np.cov(points, rowvar=False))
+    aspect_ratio = float(np.sqrt(max(eigenvalues) / max(1e-9, min(eigenvalues))))
+    aspect_score = float(np.exp(-((aspect_ratio - 1.45) / 0.65) ** 2))
     coverage = area / max(1, width * height)
-    coverage_score = min(1.0, coverage / 0.75)
+    coverage_score = min(1.0, coverage / 0.72)
 
-    score = 10 * (0.45 * circularity + 0.35 * aspect_score + 0.20 * coverage_score)
+    # A loaf has a filled-in body. Thin legs and tails create rows/columns with
+    # much shorter spans than the main body, which this robust score penalizes.
+    row_spans = np.array([np.ptp(np.flatnonzero(row)) + 1 for row in crop if row.any()])
+    col_spans = np.array([np.ptp(np.flatnonzero(col)) + 1 for col in crop.T if col.any()])
+    span_score = min(
+        np.percentile(row_spans, 25) / max(1, np.percentile(row_spans, 75)),
+        np.percentile(col_spans, 25) / max(1, np.percentile(col_spans, 75)),
+    )
+
+    score = 10 * (
+        0.25 * min(1.0, circularity / 0.55)
+        + 0.30 * aspect_score
+        + 0.25 * coverage_score
+        + 0.20 * span_score
+    )
     return {
         "score": round(float(score), 1),
         "circularity": round(float(circularity), 3),
         "aspect": round(float(aspect_ratio), 2),
         "coverage": round(float(coverage), 3),
+        "compactness": round(float(span_score), 3),
     }
 

--- a/src/pixelcat/ui/pages.py
+++ b/src/pixelcat/ui/pages.py
@@ -237,6 +237,7 @@ def render_loaf_scorer():
                 {"Metric": "Circularity", "Value": metrics["circularity"]},
                 {"Metric": "Aspect ratio", "Value": metrics["aspect"]},
                 {"Metric": "Mask coverage", "Value": metrics["coverage"]},
+                {"Metric": "Body compactness", "Value": metrics["compactness"]},
             ]
         )
 

--- a/tests/test_app_helpers.py
+++ b/tests/test_app_helpers.py
@@ -1,11 +1,16 @@
+from io import BytesIO
+
 import numpy as np
+from PIL import Image
 
 from src.pixelcat.clustering import cluster_pixels, sample_indices
+from src.pixelcat.image_processing import load_image_from_bytes
 from src.pixelcat.scores import (
     color_mismatch_score,
     distance_to_similarity,
     loaf_score,
     palette_distance,
+    rgb_to_lab,
 )
 from src.pixelcat.ui.components import palette_table_html
 
@@ -69,6 +74,21 @@ def test_palette_distance_is_symmetric():
     )
 
 
+def test_perceptual_distance_recognizes_equal_rgb_steps_are_not_equal():
+    dark_step = np.linalg.norm(rgb_to_lab((20, 20, 20)) - rgb_to_lab((50, 50, 50)))
+    light_step = np.linalg.norm(rgb_to_lab((205, 205, 205)) - rgb_to_lab((235, 235, 235)))
+    assert dark_step > light_step
+
+
+def test_jacket_visibility_is_directional():
+    cat = [{"rgb": (20, 20, 20), "percent": 100.0}]
+    matching_jacket = [
+        {"rgb": (20, 20, 20), "percent": 50.0},
+        {"rgb": (240, 240, 240), "percent": 50.0},
+    ]
+    assert color_mismatch_score(cat, matching_jacket) == 0
+
+
 def test_loaf_score_rewards_compact_oval_mask():
     rows, cols = np.ogrid[:80, :120]
     oval = ((rows - 40) / 25) ** 2 + ((cols - 60) / 42) ** 2 <= 1
@@ -78,6 +98,19 @@ def test_loaf_score_rewards_compact_oval_mask():
     assert 0 <= metrics["score"] <= 10
     assert metrics["score"] > 5
     assert metrics["aspect"] > 1
+    assert metrics["compactness"] > 0
+
+
+def test_background_removal_keeps_white_subject_connected_to_grey_backdrop():
+    pixels = np.full((20, 20, 4), (180, 180, 180, 255), dtype=np.uint8)
+    pixels[5:15, 5:15, :3] = 255
+    source = BytesIO()
+    Image.fromarray(pixels, "RGBA").save(source, format="PNG")
+
+    result = np.asarray(load_image_from_bytes(source.getvalue()))
+
+    assert result[0, 0, 3] == 0
+    assert result[10, 10, 3] == 255
 
 
 def test_sample_indices_caps_rows_reproducibly():


### PR DESCRIPTION
## What changed
- Compare cat palettes in perceptual CIE Lab color space
- Calculate jacket visibility from cat fur to fabric, without unrelated jacket colors distorting the result
- Remove connected studio backgrounds while preserving light fur and fabric
- Make loaf scoring rotation-independent and account for body compactness
- Add regression tests for the revised scoring and background handling

## Why
The previous RGB distance did not match human color perception, jacket matching was symmetric when the practical question is directional, and loaf scoring depended too heavily on image rotation and noisy edges.

## Validation
- 12 automated tests passing
- Iterated across all five sample cat images and both jacket examples